### PR TITLE
ruff/cleanup

### DIFF
--- a/pyphare/pyphare/core/box.py
+++ b/pyphare/pyphare/core/box.py
@@ -70,26 +70,26 @@ class Box:
 
 
 class nDBox(Box):
-    def __init__(self, dim, l, u):
+    def __init__(self, dim, lower, upper):
         def _get(self, p):
             return np.asarray([p] * dim)
 
-        super().__init__(_get(dim, l), _get(dim, u))
+        super().__init__(_get(dim, lower), _get(dim, upper))
 
 
 class Box1D(nDBox):
-    def __init__(self, l, u):
-        super().__init__(1, l, u)
+    def __init__(self, lower, upper):
+        super().__init__(1, lower, upper)
 
 
 class Box2D(nDBox):
-    def __init__(self, l, u):
-        super().__init__(2, l, u)
+    def __init__(self, lower, upper):
+        super().__init__(2, lower, upper)
 
 
 class Box3D(nDBox):
-    def __init__(self, l, u):
-        super().__init__(3, l, u)
+    def __init__(self, lower, upper):
+        super().__init__(3, lower, upper)
 
 
 def refine(box, ratio):

--- a/pyphare/pyphare/core/operators.py
+++ b/pyphare/pyphare/core/operators.py
@@ -9,9 +9,9 @@ def _compute_dot_product(patch_datas, **kwargs):
     ref_name = next(iter(patch_datas.keys()))
 
     dset = (
-        patch_datas["left_x"].dataset[:] * patch_datas["right_x"].dataset[:]
-        + patch_datas["left_y"].dataset[:] * patch_datas["right_y"].dataset[:]
-        + patch_datas["left_z"].dataset[:] * patch_datas["right_z"].dataset[:]
+        patch_datas["left_x"][:] * patch_datas["right_x"][:]
+        + patch_datas["left_y"][:] * patch_datas["right_y"][:]
+        + patch_datas["left_z"][:] * patch_datas["right_z"][:]
     )
 
     return (
@@ -22,7 +22,7 @@ def _compute_dot_product(patch_datas, **kwargs):
 def _compute_sqrt(patch_datas, **kwargs):
     ref_name = next(iter(patch_datas.keys()))
 
-    dset = np.sqrt(patch_datas["value"].dataset[:])
+    dset = np.sqrt(patch_datas["value"][:])
 
     return (
         {"name": "value", "data": dset, "centering": patch_datas[ref_name].centerings},
@@ -33,16 +33,16 @@ def _compute_cross_product(patch_datas, **kwargs):
     ref_name = next(iter(patch_datas.keys()))
 
     dset_x = (
-        patch_datas["left_y"].dataset[:] * patch_datas["right_z"].dataset[:]
-        - patch_datas["left_z"].dataset[:] * patch_datas["right_y"].dataset[:]
+        patch_datas["left_y"][:] * patch_datas["right_z"][:]
+        - patch_datas["left_z"][:] * patch_datas["right_y"][:]
     )
     dset_y = (
-        patch_datas["left_z"].dataset[:] * patch_datas["right_x"].dataset[:]
-        - patch_datas["left_x"].dataset[:] * patch_datas["right_z"].dataset[:]
+        patch_datas["left_z"][:] * patch_datas["right_x"][:]
+        - patch_datas["left_x"][:] * patch_datas["right_z"][:]
     )
     dset_z = (
-        patch_datas["left_x"].dataset[:] * patch_datas["right_y"].dataset[:]
-        - patch_datas["left_y"].dataset[:] * patch_datas["right_x"].dataset[:]
+        patch_datas["left_x"][:] * patch_datas["right_y"][:]
+        - patch_datas["left_y"][:] * patch_datas["right_x"][:]
     )
 
     return (
@@ -64,17 +64,11 @@ def _compute_grad(patch_data, **kwargs):
     ds_z = np.full(ds_shape, np.nan)
 
     grad_ds = np.gradient(ds)
-
+    select = tuple([slice(nb_ghosts, -nb_ghosts) for _ in range(ndim)])
     if ndim == 2:
-        ds_x[nb_ghosts:-nb_ghosts, nb_ghosts:-nb_ghosts] = np.asarray(
-            grad_ds[0][nb_ghosts:-nb_ghosts, nb_ghosts:-nb_ghosts]
-        )
-        ds_y[nb_ghosts:-nb_ghosts, nb_ghosts:-nb_ghosts] = np.asarray(
-            grad_ds[1][nb_ghosts:-nb_ghosts, nb_ghosts:-nb_ghosts]
-        )
-        ds_z[nb_ghosts:-nb_ghosts, nb_ghosts:-nb_ghosts].fill(
-            0.0
-        )  # TODO at 2D, gradient is null in z dir
+        ds_x[select] = np.asarray(grad_ds[0][select])
+        ds_y[select] = np.asarray(grad_ds[1][select])
+        ds_z[select].fill(0.0)  # TODO at 2D, gradient is null in z dir
 
     else:
         raise RuntimeError("dimension not yet implemented")

--- a/pyphare/pyphare/core/phare_utilities.py
+++ b/pyphare/pyphare/core/phare_utilities.py
@@ -155,7 +155,8 @@ def run_cli_cmd(cmd, shell=True, capture_output=True, check=False, print_cmd=Fal
 
 
 def print_trace():
-    import sys, traceback
+    import sys
+    import traceback
 
     _, _, tb = sys.exc_info()
     traceback.print_tb(tb)

--- a/pyphare/pyphare/cpp/__init__.py
+++ b/pyphare/pyphare/cpp/__init__.py
@@ -22,7 +22,7 @@ def cpp_lib(override=None):
         return importlib.import_module("pybindlibs.cpp")
     try:
         return importlib.import_module("pybindlibs.cpp_dbg")
-    except ImportError as err:
+    except ImportError:
         return importlib.import_module("pybindlibs.cpp")
 
 

--- a/pyphare/pyphare/pharein/__init__.py
+++ b/pyphare/pyphare/pharein/__init__.py
@@ -4,6 +4,33 @@ import subprocess
 import numpy as np
 
 from pyphare.core.phare_utilities import is_scalar
+from .uniform_model import UniformModel
+from .maxwellian_fluid_model import MaxwellianFluidModel
+from .electron_model import ElectronModel
+from .diagnostics import (
+    FluidDiagnostics,
+    ElectromagDiagnostics,
+    ParticleDiagnostics,
+    MetaDiagnostics,
+    InfoDiagnostics,
+)
+from .simulation import (
+    Simulation,
+    serialize as serialize_sim,
+    deserialize as deserialize_sim,
+)
+
+__all__ = [
+    "UniformModel",
+    "MaxwellianFluidModel",
+    "ElectronModel",
+    "FluidDiagnostics",
+    "ElectromagDiagnostics",
+    "ParticleDiagnostics",
+    "MetaDiagnostics",
+    "InfoDiagnostics",
+    "Simulation",
+]
 
 # This exists to allow a condition variable for when we are running PHARE from C++ via phare-exe
 #  It is configured to "True" in pyphare/pyphare/pharein/init.py::get_user_inputs(jobname)
@@ -27,23 +54,6 @@ if venv_path is not None:
     s = s.split(",")[1:]
     pythonpath = [ss.strip() for ss in s]
     sys.path = sys.path + pythonpath
-
-
-from .uniform_model import UniformModel
-from .maxwellian_fluid_model import MaxwellianFluidModel
-from .electron_model import ElectronModel
-from .diagnostics import (
-    FluidDiagnostics,
-    ElectromagDiagnostics,
-    ParticleDiagnostics,
-    MetaDiagnostics,
-    InfoDiagnostics,
-)
-from .simulation import (
-    Simulation,
-    serialize as serialize_sim,
-    deserialize as deserialize_sim,
-)
 
 
 def NO_GUI():

--- a/pyphare/pyphare/pharein/diagnostics.py
+++ b/pyphare/pyphare/pharein/diagnostics.py
@@ -147,7 +147,7 @@ class Diagnostics(object):
 
         self.__extent = None
 
-        # if a diag already is registered we just contactenate the timestamps
+        # if a diag already is registered we just concatenate the timestamps
         addIt = True
         registered_diags = global_vars.sim.diagnostics
         for diagname, diag in registered_diags.items():
@@ -313,7 +313,6 @@ class ParticleDiagnostics(Diagnostics):
         )
 
     def _setSubTypeAttributes(self, **kwargs):
-
         # domain is good default for users who should not worry about what that means
         # even less about ghosts...
         kwargs["quantity"] = kwargs.get("quantity", "domain")

--- a/pyphare/pyphare/pharein/examples/job.py
+++ b/pyphare/pyphare/pharein/examples/job.py
@@ -1,19 +1,14 @@
 #!/usr/bin/env python
 
-
-from pyphare.pharein import Simulation
-from pyphare.pharein import MaxwellianFluidModel
-from pyphare.pharein import ElectronModel
-from pyphare.pharein import ElectromagDiagnostics
-from pyphare.pharein import FluidDiagnostics
-from pyphare.pharein import getSimulation
+import numpy as np
+import pyphare.pharein as ph
 
 
 # ------------------------------------
 #     configure the simulation
 # ------------------------------------
 
-Simulation(
+ph.Simulation(
     time_step_nbr=1000,  # number of time steps (not specified if time_step and final_time provided)
     final_time=1.0,  # simulation final time (not specified if time_step and time_step_nbr given)
     boundary_types="periodic",  # boundary condition, string or tuple, length == len(cell) == len(dl)
@@ -36,7 +31,6 @@ Simulation(
 
 # in the following we use the MaxwellianFluidModel
 
-import numpy as np
 
 Te = 0.12
 
@@ -46,17 +40,17 @@ def n(x):
 
 
 def bx(x):
-    xmax = getSimulation().simulation_domain()[0]
+    xmax = ph.getSimulation().simulation_domain()[0]
     return np.cos(2 * np.pi / xmax * x)
 
 
-MaxwellianFluidModel(bx=bx, protons={"density": n}, background={})
+ph.MaxwellianFluidModel(bx=bx, protons={"density": n}, background={})
 
 
-ElectronModel(closure="isothermal", Te=Te)
+ph.ElectronModel(closure="isothermal", Te=Te)
 
 
-ElectromagDiagnostics(
+ph.ElectromagDiagnostics(
     diag_type="E",  # available : ("E", "B")
     write_every=10,
     compute_every=5,
@@ -66,7 +60,7 @@ ElectromagDiagnostics(
 )
 
 
-FluidDiagnostics(
+ph.FluidDiagnostics(
     diag_type="density",  # choose in (rho_s, flux_s)
     write_every=10,  # write on disk every x iterations
     compute_every=5,  # compute diagnostics every x iterations ( x <= write_every)
@@ -77,7 +71,7 @@ FluidDiagnostics(
 )
 
 
-FluidDiagnostics(
+ph.FluidDiagnostics(
     diag_type="bulkVelocity",
     write_every=10,
     compute_every=5,
@@ -86,7 +80,7 @@ FluidDiagnostics(
     population_name="background",
 )
 
-FluidDiagnostics(
+ph.FluidDiagnostics(
     diag_type="density",
     write_every=10,
     compute_every=5,
@@ -95,7 +89,7 @@ FluidDiagnostics(
     population_name="all",
 )
 
-FluidDiagnostics(
+ph.FluidDiagnostics(
     diag_type="flux",
     write_every=10,
     compute_every=5,
@@ -104,9 +98,9 @@ FluidDiagnostics(
     population_name="background",
 )
 
-ElectromagDiagnostics(
+ph.ElectromagDiagnostics(
     diag_type="B", write_every=10, compute_every=5, start_teration=0, last_iteration=990
 )
 
-for item in getSimulation().electrons.dict_path():
+for item in ph.getSimulation().electrons.dict_path():
     print(item[0], item[1])

--- a/pyphare/pyphare/pharein/maxwellian_fluid_model.py
+++ b/pyphare/pyphare/pharein/maxwellian_fluid_model.py
@@ -1,7 +1,7 @@
 import numpy as np
 from pyphare.core import phare_utilities
 from pyphare.core.box import Box
-from pyphare.core.gridlayout import GridLayout, yee_element_is_primal
+from pyphare.core.gridlayout import GridLayout
 from pyphare.pharein import global_vars
 
 

--- a/pyphare/pyphare/pharein/restarts.py
+++ b/pyphare/pyphare/pharein/restarts.py
@@ -21,14 +21,14 @@ def validate(sim):
 
         if not np.all(np.diff(restart_options["elapsed_timestamps"]) >= 0):
             raise RuntimeError(
-                f"Error: restart_options elapsed_timestamps not in ascending order)"
+                "Error: restart_options elapsed_timestamps not in ascending order)"
             )
 
         # seconds_in_an_hour = 60 ** 2
         # for cmp_idx, ref_ts in enumerate(restart_options["elapsed_timestamps"][1:]):
         #     cmp_ts = restart_options["elapsed_timestamps"][cmp_idx]
         #     if ref_ts - cmp_ts < seconds_in_an_hour:
-        #         raise RuntimeError(f"Error: time betweeen restart_options elapsed_timestamps must be at least one hour)")
+        #         raise RuntimeError("Error: time betweeen restart_options elapsed_timestamps must be at least one hour)")
 
     if "timestamps" in restart_options:
         restart_options["timestamps"] = phare_utilities.np_array_ify(
@@ -47,7 +47,7 @@ def validate(sim):
             )
         if not np.all(np.diff(timestamps) >= 0):
             raise RuntimeError(
-                f"Error: restart_options timestamps not in ascending order)"
+                "Error: restart_options timestamps not in ascending order)"
             )
         if not np.all(
             np.abs(
@@ -55,7 +55,7 @@ def validate(sim):
             )
         ):
             raise RuntimeError(
-                f"Error: restart_options timestamps is inconsistent with simulation.time_step"
+                "Error: restart_options timestamps is inconsistent with simulation.time_step"
             )
 
         sim.restart_options["timestamps"] = conserve_existing(sim)

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -326,7 +326,7 @@ def check_refinement_boxes(ndim, **kwargs):
 
         for box_idx, ref_box in enumerate(boxes):
             for cmp_box in boxes[box_idx + 1 :]:
-                if ref_box * cmp_box != None:
+                if ref_box * cmp_box is not None:
                     raise ValueError(
                         f"Error: Box({ref_box}) overlaps with Box({cmp_box})"
                     )
@@ -346,8 +346,8 @@ def check_refinement_boxes(ndim, **kwargs):
 
             if box.ndim != ndim:
                 raise ValueError(f"Box({box}) has incorrect dimensions for simulation")
-            for l in boxm.refine(box, refinement_ratio).shape:
-                if (l < smallest_patch_size).any():
+            for length in boxm.refine(box, refinement_ratio).shape:
+                if (length < smallest_patch_size).any():
                     raise ValueError(
                         "Invalid box incompatible with smallest_patch_size"
                     )
@@ -552,7 +552,7 @@ def check_optional_keywords(**kwargs):
 def check_resistivity(**kwargs):
     resistivity = kwargs.get("resistivity", 0.0)
     if resistivity < 0.0:
-        raise ValueError(f"Error: resistivity should not be negative")
+        raise ValueError("Error: resistivity should not be negative")
 
     return resistivity
 
@@ -560,7 +560,7 @@ def check_resistivity(**kwargs):
 def check_hyper_resistivity(**kwargs):
     hyper_resistivity = kwargs.get("hyper_resistivity", 0.0001)
     if hyper_resistivity < 0.0:
-        raise ValueError(f"Error: hyper_resistivity should not be negative")
+        raise ValueError("Error: hyper_resistivity should not be negative")
 
     return hyper_resistivity
 
@@ -669,7 +669,7 @@ def checker(func):
             ) = check_refinement_boxes(ndim, **kwargs)
         else:
             kwargs["max_nbr_levels"] = kwargs.get("max_nbr_levels", None)
-            assert kwargs["max_nbr_levels"] != None  # this needs setting otherwise
+            assert kwargs["max_nbr_levels"] is not None  # this needs setting otherwise
             kwargs["refinement_boxes"] = None
 
         kwargs["resistivity"] = check_resistivity(**kwargs)
@@ -932,12 +932,14 @@ class Simulation(object):
 
 def serialize(sim):
     # pickle cannot handle simulation objects
-    import dill, codecs
+    import dill
+    import codecs
 
     return codecs.encode(dill.dumps(sim), "hex")
 
 
 def deserialize(hex):
-    import dill, codecs
+    import dill
+    import codecs
 
     return dill.loads(codecs.decode(hex, "hex"))

--- a/pyphare/pyphare/pharesee/hierarchy/__init__.py
+++ b/pyphare/pyphare/pharesee/hierarchy/__init__.py
@@ -1,9 +1,13 @@
-from .fromh5 import hierarchy_fromh5
-from .fromsim import hierarchy_from_sim
 from .scalarfield import ScalarField
 from .vectorfield import VectorField
 from .hierarchy import PatchHierarchy
 from pyphare.core.phare_utilities import listify
+
+__all__ = [
+    "ScalarField",
+    "VectorField",
+    "PatchHierarchy",
+]
 
 
 def hierarchy_from(

--- a/pyphare/pyphare/pharesee/hierarchy/fromh5.py
+++ b/pyphare/pyphare/pharesee/hierarchy/fromh5.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from pyphare.core.phare_utilities import listify
 
 
+h5_time_grp_key = "t"
 particle_files_patterns = ("domain", "patchGhost", "levelGhost")
 
 
@@ -129,17 +130,13 @@ def h5_filename_from(diagInfo):
 
 
 def get_times_from_h5(filepath, as_float=True):
-
     f = h5py.File(filepath, "r")
     if as_float:
-        times = np.array(sorted([float(s) for s in list(f["t"].keys())]))
+        times = np.array(sorted([float(s) for s in list(f[h5_time_grp_key].keys())]))
     else:
-        times = list(f["t"].keys())
+        times = list(f[h5_time_grp_key].keys())
     f.close()
     return times
-
-
-h5_time_grp_key = "t"
 
 
 def create_from_all_times(time, hier):
@@ -163,7 +160,6 @@ def patch_levels_from_h5(h5f, time, selection_box=None):
     creates a dictionary of PatchLevels from a given time in a h5 file
     {ilvl: PatchLevel}
     """
-    import os
 
     root_cell_width = h5f.attrs["cell_width"]
     interp_order = h5f.attrs["interpOrder"]
@@ -171,8 +167,7 @@ def patch_levels_from_h5(h5f, time, selection_box=None):
 
     patch_levels = {}
 
-    for lvl_key, lvl in h5f["t"][time].items():
-
+    for lvl_key, lvl in h5f[h5_time_grp_key][time].items():
         ilvl = int(lvl_key[2:])  # pl1-->1
         lvl_cell_width = root_cell_width / refinement_ratio**ilvl
 
@@ -322,5 +317,4 @@ def hierarchy_fromh5(h5_filename, time=None, hier=None, silent=True, **kwargs):
             add_time_from_h5(hier, h5_filename, t, **kwargs)
         return hier
 
-    print("SHOULD NOT BE THERE : ", time, hier)
     assert False

--- a/pyphare/pyphare/pharesee/hierarchy/hierarchy_utils.py
+++ b/pyphare/pyphare/pharesee/hierarchy/hierarchy_utils.py
@@ -431,7 +431,7 @@ def compute_rename(patch_datas, **kwargs):
 
 
 def rename(hierarchy, names):
-    return compute_hier_from(_compute_rename, hierarchy, names=names)
+    return compute_hier_from(compute_rename, hierarchy, names=names)
 
 
 def _compute_mul(patch_datas, **kwargs):

--- a/pyphare/pyphare/pharesee/hierarchy/patch.py
+++ b/pyphare/pyphare/pharesee/hierarchy/patch.py
@@ -1,4 +1,4 @@
-from .patchdata import PatchData
+#
 
 
 class Patch:

--- a/pyphare/pyphare/pharesee/hierarchy/patchdata.py
+++ b/pyphare/pyphare/pharesee/hierarchy/patchdata.py
@@ -104,8 +104,10 @@ class FieldData(PatchData):
                 return self.dataset[lower[0] : upper[0] + 1, lower[1] : upper[1] + 1]
         return np.array([])
 
-    def __getitem__(self, box):
-        return self.select(box)
+    def __getitem__(self, box_or_slice):
+        if isinstance(box_or_slice, slice):
+            return self.dataset[box_or_slice]
+        return self.select(box_or_slice)
 
     def __init__(self, layout, field_name, data, **kwargs):
         """

--- a/pyphare/pyphare/pharesee/hierarchy/scalarfield.py
+++ b/pyphare/pyphare/pharesee/hierarchy/scalarfield.py
@@ -26,7 +26,6 @@ class ScalarField(PatchHierarchy):
             )
         elif isinstance(other, (int, float)):
             h = compute_hier_from(self._compute_add, (h_self,), other=other)
-            pass
         else:
             raise RuntimeError("right operand not supported")
 

--- a/pyphare/pyphare/pharesee/hierarchy/vectorfield.py
+++ b/pyphare/pyphare/pharesee/hierarchy/vectorfield.py
@@ -6,7 +6,6 @@ from .hierarchy_utils import (
     _compute_mul,
     _compute_add,
     _compute_sub,
-    _compute_neg,
     _compute_truediv,
     _compute_scalardiv,
 )

--- a/pyphare/pyphare/pharesee/particles.py
+++ b/pyphare/pyphare/pharesee/particles.py
@@ -85,7 +85,7 @@ class Particles:
                 all_assert_sorted(self, that)
                 return True
             except AssertionError as ex:
-                print(f"particles.py:Particles::eq failed with:", ex)
+                print(f"particles.py:Particles::eq failed with: {ex}")
                 print_trace()
                 return False
 

--- a/pyphare/pyphare/pharesee/plotting.py
+++ b/pyphare/pyphare/pharesee/plotting.py
@@ -248,14 +248,12 @@ def finest_field_plot(run_path, qty, **kwargs):
     from pyphare.pharesee.hierarchy.fromh5 import get_times_from_h5
     from pyphare.pharesee.run import Run
     from mpl_toolkits.axes_grid1 import make_axes_locatable
-    import pyphare.core.gridlayout as gridlayout
 
     r = Run(run_path)
 
     time = kwargs.get("time", None)
     dim = r.GetDl("finest", time).shape[0]
     interp = kwargs.get("interp", "nearest")
-    domain = r.GetDomainSize()
 
     if qty in ["Bx", "By", "Bz"]:
         file = os.path.join(run_path, "EM_B.h5")

--- a/pyphare/pyphare/pharesee/run.py
+++ b/pyphare/pyphare/pharesee/run.py
@@ -7,7 +7,6 @@ from pyphare.pharesee.hierarchy import ScalarField, VectorField
 from pyphare.core.gridlayout import yee_centering
 from .hierarchy.hierarchy_utils import compute_hier_from
 from .hierarchy.hierarchy_utils import flat_finest_field
-from .hierarchy import hierarchy_from
 from pyphare.core.phare_utilities import listify
 
 from pyphare.logger import getLogger
@@ -613,9 +612,9 @@ class Run:
         return self._get(P, time, merged, interp)  # should later be a TensorField
 
     def GetPi(self, time, merged=False, interp="nearest", **kwargs):
-        M = self._get_hierarchy(time, f"ions_momentum_tensor.h5", **kwargs)
+        M = self._get_hierarchy(time, "ions_momentum_tensor.h5", **kwargs)
         massDensity = self.GetMassDensity(time, **kwargs)
-        Vi = self._get_hierarchy(time, f"ions_bulkVelocity.h5", **kwargs)
+        Vi = self._get_hierarchy(time, "ions_bulkVelocity.h5", **kwargs)
         Pi = compute_hier_from(_compute_pressure, (M, massDensity, Vi))
         return self._get(Pi, time, merged, interp)  # should later be a TensorField
 

--- a/pyphare/pyphare/simulator/simulator.py
+++ b/pyphare/pyphare/simulator/simulator.py
@@ -138,7 +138,7 @@ class Simulator:
         except KeyboardInterrupt as e:
             self._throw(f"KeyboardInterrupt in simulator.py::advance: \n{e}")
 
-        if self._auto_dump() and self.post_advance != None:
+        if self._auto_dump() and self.post_advance is not None:
             self.post_advance(self.cpp_sim.currentTime())
         return self
 

--- a/pyphare/pyphare_tests/test_pharesee/__init__.py
+++ b/pyphare/pyphare_tests/test_pharesee/__init__.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 import pyphare.core.box as boxm
-from pyphare.core.box import Box, nDBox
+from pyphare.core.box import Box
 from pyphare.core.phare_utilities import listify
 from pyphare.core.gridlayout import GridLayout, yee_element_is_primal
 
@@ -241,9 +241,6 @@ def build_hierarchy(**kwargs):
 
     - nbr_cells
     - origin
-    - interp_order
-    - domain_size
-    - cell_width
     - refinement_ratio
     - refinement_boxes
     """
@@ -254,9 +251,6 @@ def build_hierarchy(**kwargs):
     dim = len(origin)
     if dim > 1:
         assert len(nbr_cells) == dim
-    interp_order = kwargs["interp_order"]
-    domain_size = kwargs["domain_size"]
-    cell_width = kwargs["cell_width"]
     refinement_ratio = kwargs["refinement_ratio"]
 
     domain_box = boxm.Box([0] * dim, nbr_cells - 1)

--- a/pyphare/pyphare_tests/test_pharesee/test_geometry.py
+++ b/pyphare/pyphare_tests/test_pharesee/test_geometry.py
@@ -292,7 +292,7 @@ class GeometryTest(unittest.TestCase):
 
             for ref_box_i, ref_box in enumerate(periodic_boxes):
                 for cmp_box in periodic_boxes[ref_box_i + 1 :]:
-                    self.assertTrue(ref_box * cmp_box == None)
+                    self.assertTrue(ref_box * cmp_box is None)
 
             self.assertEqual(expected[ilvl], periodic_boxes)
 

--- a/pyphare/pyphare_tests/test_pharesee/test_geometry_2d.py
+++ b/pyphare/pyphare_tests/test_pharesee/test_geometry_2d.py
@@ -9,7 +9,6 @@ from pyphare.pharesee.geometry import (
     ghost_area_boxes,
     get_periodic_list,
 )
-from pyphare.core.gridlayout import GridLayout, yee_element_is_primal
 
 from pyphare_tests.test_pharesee import build_hierarchy
 
@@ -163,7 +162,6 @@ class GeometryTest(AGeometryTest):
 
         level_overlaps = hierarchy_overlaps(hierarchy)
         ilvl = 0
-        lvl = hierarchy.level(ilvl)
         overlap_boxes = []
 
         self.assertEqual(len(expected), len(level_overlaps[ilvl]))

--- a/pyphare/pyphare_tests/test_pharesee/test_hierarchy.py
+++ b/pyphare/pyphare_tests/test_pharesee/test_hierarchy.py
@@ -1,5 +1,5 @@
 import unittest
-from ddt import ddt, data, unpack
+from ddt import ddt
 import numpy as np
 
 from pyphare.simulator.simulator import Simulator
@@ -18,7 +18,6 @@ timestamps = dt * np.arange(nt)
 
 @ddt
 class PatchHierarchyTest(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         from pyphare.pharein import global_vars


### PR DESCRIPTION
~60 or so things from `ruff`

```
pyphare/pyphare/core/box.py:73:29: E741 Ambiguous variable name: `l`
pyphare/pyphare/core/box.py:81:24: E741 Ambiguous variable name: `l`
pyphare/pyphare/core/box.py:86:24: E741 Ambiguous variable name: `l`
pyphare/pyphare/core/box.py:91:24: E741 Ambiguous variable name: `l`
pyphare/pyphare/core/phare_utilities.py:158:5: E401 [*] Multiple imports on one line
pyphare/pyphare/cpp/__init__.py:25:27: F841 [*] Local variable `err` is assigned to but never used
pyphare/pyphare/pharein/__init__.py:32:1: E402 Module level import not at top of file
pyphare/pyphare/pharein/__init__.py:32:28: F401 `.uniform_model.UniformModel` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
pyphare/pyphare/pharein/__init__.py:33:1: E402 Module level import not at top of file
pyphare/pyphare/pharein/__init__.py:33:37: F401 `.maxwellian_fluid_model.MaxwellianFluidModel` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
pyphare/pyphare/pharein/__init__.py:34:1: E402 Module level import not at top of file
pyphare/pyphare/pharein/__init__.py:34:29: F401 `.electron_model.ElectronModel` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
pyphare/pyphare/pharein/__init__.py:35:1: E402 Module level import not at top of file
pyphare/pyphare/pharein/__init__.py:36:5: F401 `.diagnostics.FluidDiagnostics` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
pyphare/pyphare/pharein/__init__.py:37:5: F401 `.diagnostics.ElectromagDiagnostics` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
pyphare/pyphare/pharein/__init__.py:38:5: F401 `.diagnostics.ParticleDiagnostics` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
pyphare/pyphare/pharein/__init__.py:39:5: F401 `.diagnostics.MetaDiagnostics` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
pyphare/pyphare/pharein/__init__.py:40:5: F401 `.diagnostics.InfoDiagnostics` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
pyphare/pyphare/pharein/__init__.py:42:1: E402 Module level import not at top of file
pyphare/pyphare/pharein/__init__.py:43:5: F401 `.simulation.Simulation` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
pyphare/pyphare/pharein/examples/job.py:39:1: E402 Module level import not at top of file
pyphare/pyphare/pharein/init.py:8:5: F841 Local variable `jobmodule` is assigned to but never used
pyphare/pyphare/pharein/maxwellian_fluid_model.py:4:49: F401 [*] `pyphare.core.gridlayout.yee_element_is_primal` imported but unused
pyphare/pyphare/pharein/restarts.py:24:17: F541 [*] f-string without any placeholders
pyphare/pyphare/pharein/restarts.py:50:17: F541 [*] f-string without any placeholders
pyphare/pyphare/pharein/restarts.py:58:17: F541 [*] f-string without any placeholders
pyphare/pyphare/pharein/simulation.py:329:41: E711 Comparison to `None` should be `cond is not None`
pyphare/pyphare/pharein/simulation.py:349:17: E741 Ambiguous variable name: `l`
pyphare/pyphare/pharein/simulation.py:555:26: F541 [*] f-string without any placeholders
pyphare/pyphare/pharein/simulation.py:563:26: F541 [*] f-string without any placeholders
pyphare/pyphare/pharein/simulation.py:672:48: E711 Comparison to `None` should be `cond is not None`
pyphare/pyphare/pharein/simulation.py:935:5: E401 [*] Multiple imports on one line
pyphare/pyphare/pharein/simulation.py:941:5: E401 [*] Multiple imports on one line
pyphare/pyphare/pharesee/hierarchy/__init__.py:1:21: F401 `.fromh5.hierarchy_fromh5` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
pyphare/pyphare/pharesee/hierarchy/__init__.py:2:22: F401 `.fromsim.hierarchy_from_sim` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
pyphare/pyphare/pharesee/hierarchy/__init__.py:3:26: F401 `.scalarfield.ScalarField` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
pyphare/pyphare/pharesee/hierarchy/__init__.py:4:26: F401 `.vectorfield.VectorField` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
pyphare/pyphare/pharesee/hierarchy/__init__.py:5:24: F401 `.hierarchy.PatchHierarchy` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
pyphare/pyphare/pharesee/hierarchy/__init__.py:12:25: F811 [*] Redefinition of unused `hierarchy_fromh5` from line 1
pyphare/pyphare/pharesee/hierarchy/__init__.py:13:26: F811 [*] Redefinition of unused `hierarchy_from_sim` from line 2
pyphare/pyphare/pharesee/hierarchy/hierarchy_utils.py:434:30: F821 Undefined name `_compute_rename`
pyphare/pyphare/pharesee/hierarchy/patch.py:1:24: F401 [*] `.patchdata.PatchData` imported but unused
pyphare/pyphare/pharesee/hierarchy/vectorfield.py:9:5: F401 [*] `.hierarchy_utils._compute_neg` imported but unused
pyphare/pyphare/pharesee/particles.py:88:23: F541 [*] f-string without any placeholders
pyphare/pyphare/pharesee/plotting.py:251:39: F401 [*] `pyphare.core.gridlayout` imported but unused
pyphare/pyphare/pharesee/plotting.py:258:5: F841 Local variable `domain` is assigned to but never used
pyphare/pyphare/pharesee/plotting.py:330:9: F841 Local variable `cb` is assigned to but never used
pyphare/pyphare/pharesee/run.py:10:24: F811 Redefinition of unused `hierarchy_from` from line 4
pyphare/pyphare/pharesee/run.py:616:39: F541 [*] f-string without any placeholders
pyphare/pyphare/pharesee/run.py:618:40: F541 [*] f-string without any placeholders
pyphare/pyphare/simulator/simulator.py:86:9: E722 Do not use bare `except`
pyphare/pyphare/simulator/simulator.py:109:9: E722 Do not use bare `except`
pyphare/pyphare/simulator/simulator.py:141:55: E711 Comparison to `None` should be `cond is not None`
pyphare/pyphare_tests/test_pharesee/__init__.py:4:35: F401 `pyphare.core.box.nDBox` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
pyphare/pyphare_tests/test_pharesee/__init__.py:257:5: F841 Local variable `interp_order` is assigned to but never used
pyphare/pyphare_tests/test_pharesee/__init__.py:258:5: F841 Local variable `domain_size` is assigned to but never used
pyphare/pyphare_tests/test_pharesee/__init__.py:259:5: F841 Local variable `cell_width` is assigned to but never used
pyphare/pyphare_tests/test_pharesee/test_geometry.py:119:9: F841 Local variable `particles` is assigned to but never used
pyphare/pyphare_tests/test_pharesee/test_geometry.py:295:58: E711 Comparison to `None` should be `cond is None`
pyphare/pyphare_tests/test_pharesee/test_geometry_2d.py:12:37: F401 [*] `pyphare.core.gridlayout.GridLayout` imported but unused
pyphare/pyphare_tests/test_pharesee/test_geometry_2d.py:12:49: F401 [*] `pyphare.core.gridlayout.yee_element_is_primal` imported but unused
pyphare/pyphare_tests/test_pharesee/test_geometry_2d.py:166:9: F841 Local variable `lvl` is assigned to but never used
pyphare/pyphare_tests/test_pharesee/test_hierarchy.py:2:22: F401 [*] `ddt.data` imported but unused
pyphare/pyphare_tests/test_pharesee/test_hierarchy.py:2:28: F401 [*] `ddt.unpack` imported but unused
pyphare/pyphare_tests/test_pharesee/test_hierarchy.py:53:26: E741 Ambiguous variable name: `l`
Found 68 errors.
[*] 22 fixable with the `--fix` option (13 hidden fixes can be enabled with the `--unsafe-fixes` option).
```